### PR TITLE
Use RWMutex instead of Mutex

### DIFF
--- a/pkg/linkedlist/blocking.go
+++ b/pkg/linkedlist/blocking.go
@@ -26,7 +26,7 @@ import (
 // or the list is closed.
 type Blocking[T any, P Pointer[T]] struct {
 	_padding0 [8]uint64 //nolint:structcheck,unused
-	lock      *sync.Mutex
+	lock      *sync.RWMutex
 	_padding1 [8]uint64 //nolint:structcheck,unused
 	head      *Node[T, P]
 	_padding2 [8]uint64 //nolint:structcheck,unused
@@ -45,7 +45,7 @@ type Blocking[T any, P Pointer[T]] struct {
 // FIFO queue when used with the Push and Pop methods.
 func NewBlocking[T any, P Pointer[T]]() *Blocking[T, P] {
 	l := new(Blocking[T, P])
-	l.lock = new(sync.Mutex)
+	l.lock = new(sync.RWMutex)
 	l.notEmpty = sync.NewCond(l.lock)
 	l.pool = pool.NewPool[Node[T, P], *Node[T, P]](NewNode[T, P])
 	return l
@@ -56,9 +56,9 @@ func NewBlocking[T any, P Pointer[T]]() *Blocking[T, P] {
 //
 // The Drain method can be used to drain the list after it is closed.
 func (l *Blocking[T, P]) IsClosed() (closed bool) {
-	l.lock.Lock()
+	l.lock.RLock()
 	closed = l.isClosed()
-	l.lock.Unlock()
+	l.lock.RUnlock()
 	return
 }
 
@@ -80,9 +80,9 @@ func (l *Blocking[T, P]) Close() {
 
 // Length returns the count of nodes stored in the Blocking linked list
 func (l *Blocking[T, P]) Length() (len uint64) {
-	l.lock.Lock()
+	l.lock.RLock()
 	len = l.len
-	l.lock.Unlock()
+	l.lock.RUnlock()
 	return
 }
 

--- a/pkg/linkedlist/double.go
+++ b/pkg/linkedlist/double.go
@@ -32,7 +32,7 @@ func NewDouble[T any, P Pointer[T]]() *Double[T, P] {
 // Double is a double-linked list
 type Double[T any, P Pointer[T]] struct {
 	_padding0 [8]uint64 //nolint:structcheck,unused
-	lock      sync.Mutex
+	lock      sync.RWMutex
 	_padding1 [8]uint64 //nolint:structcheck,unused
 	head      *Node[T, P]
 	_padding2 [8]uint64 //nolint:structcheck,unused
@@ -45,9 +45,9 @@ type Double[T any, P Pointer[T]] struct {
 
 // Length returns the count of nodes stored in the double linked list
 func (l *Double[T, P]) Length() (len uint64) {
-	l.lock.Lock()
+	l.lock.RLock()
 	len = l.len
-	l.lock.Unlock()
+	l.lock.RUnlock()
 	return
 }
 

--- a/pkg/queue/circular.go
+++ b/pkg/queue/circular.go
@@ -33,7 +33,7 @@ type Circular[T any, P Pointer[T]] struct {
 	_padding3 [8]uint64 //nolint:structcheck,unused
 	closed    bool
 	_padding4 [8]uint64 //nolint:structcheck,unused
-	lock      *sync.Mutex
+	lock      *sync.RWMutex
 	_padding5 [8]uint64 //nolint:structcheck,unused
 	notEmpty  *sync.Cond
 	_padding6 [8]uint64 //nolint:structcheck,unused
@@ -45,7 +45,7 @@ type Circular[T any, P Pointer[T]] struct {
 // NewCircular creates a new circular queue with the given size.
 func NewCircular[T any, P Pointer[T]](maxSize uint64) *Circular[T, P] {
 	q := new(Circular[T, P])
-	q.lock = new(sync.Mutex)
+	q.lock = new(sync.RWMutex)
 	q.notFull = sync.NewCond(q.lock)
 	q.notEmpty = sync.NewCond(q.lock)
 
@@ -64,9 +64,9 @@ func NewCircular[T any, P Pointer[T]](maxSize uint64) *Circular[T, P] {
 
 // IsEmpty returns true if the queue is empty.
 func (q *Circular[T, P]) IsEmpty() (empty bool) {
-	q.lock.Lock()
+	q.lock.RLock()
 	empty = q.isEmpty()
-	q.lock.Unlock()
+	q.lock.RUnlock()
 	return
 }
 
@@ -78,9 +78,9 @@ func (q *Circular[T, P]) isEmpty() bool {
 
 // IsFull returns true if the queue is full.
 func (q *Circular[T, P]) IsFull() (full bool) {
-	q.lock.Lock()
+	q.lock.RLock()
 	full = q.isFull()
-	q.lock.Unlock()
+	q.lock.RUnlock()
 	return
 }
 
@@ -94,9 +94,9 @@ func (q *Circular[T, P]) isFull() bool {
 //
 // The Drain method can be used to drain the queue after it is closed.
 func (q *Circular[T, P]) IsClosed() (closed bool) {
-	q.lock.Lock()
+	q.lock.RLock()
 	closed = q.isClosed()
-	q.lock.Unlock()
+	q.lock.RUnlock()
 	return
 }
 
@@ -108,9 +108,9 @@ func (q *Circular[T, P]) isClosed() bool {
 
 // Length returns the number of elements in the queue.
 func (q *Circular[T, P]) Length() (size int) {
-	q.lock.Lock()
+	q.lock.RLock()
 	size = q.length()
-	q.lock.Unlock()
+	q.lock.RUnlock()
 	return
 }
 

--- a/pkg/queue/nonblocking.go
+++ b/pkg/queue/nonblocking.go
@@ -33,7 +33,7 @@ type NonBlocking[T any, P Pointer[T]] struct {
 	_padding3 [8]uint64 //nolint:structcheck,unused
 	closed    bool
 	_padding4 [8]uint64 //nolint:structcheck,unused
-	lock      *sync.Mutex
+	lock      *sync.RWMutex
 	_padding5 [8]uint64 //nolint:structcheck,unused
 	nodes     []P
 }
@@ -41,7 +41,7 @@ type NonBlocking[T any, P Pointer[T]] struct {
 // NewNonBlocking creates a new circular queue with the given size.
 func NewNonBlocking[T any, P Pointer[T]](maxSize uint64) *NonBlocking[T, P] {
 	q := new(NonBlocking[T, P])
-	q.lock = new(sync.Mutex)
+	q.lock = new(sync.RWMutex)
 	q.head = 0
 	q.tail = 0
 	maxSize++
@@ -57,9 +57,9 @@ func NewNonBlocking[T any, P Pointer[T]](maxSize uint64) *NonBlocking[T, P] {
 
 // IsEmpty returns true if the queue is empty.
 func (q *NonBlocking[T, P]) IsEmpty() (empty bool) {
-	q.lock.Lock()
+	q.lock.RLock()
 	empty = q.isEmpty()
-	q.lock.Unlock()
+	q.lock.RUnlock()
 	return
 }
 
@@ -71,9 +71,9 @@ func (q *NonBlocking[T, P]) isEmpty() bool {
 
 // IsFull returns true if the queue is full.
 func (q *NonBlocking[T, P]) IsFull() (full bool) {
-	q.lock.Lock()
+	q.lock.RLock()
 	full = q.isFull()
-	q.lock.Unlock()
+	q.lock.RUnlock()
 	return
 }
 
@@ -87,9 +87,9 @@ func (q *NonBlocking[T, P]) isFull() bool {
 //
 // The Drain method can be used to drain the queue after it is closed.
 func (q *NonBlocking[T, P]) IsClosed() (closed bool) {
-	q.lock.Lock()
+	q.lock.RLock()
 	closed = q.isClosed()
-	q.lock.Unlock()
+	q.lock.RUnlock()
 	return
 }
 
@@ -101,9 +101,9 @@ func (q *NonBlocking[T, P]) isClosed() bool {
 
 // Length returns the number of elements in the queue.
 func (q *NonBlocking[T, P]) Length() (size int) {
-	q.lock.Lock()
+	q.lock.RLock()
 	size = q.length()
-	q.lock.Unlock()
+	q.lock.RUnlock()
 	return
 }
 


### PR DESCRIPTION
## Description

Updated the Mutex with RWMutex; Some operations are required to operate with RLock instead of full Lock.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue) [title: 'fix:']
- [ ] New feature (non-breaking change which adds functionality) [title: 'feat:']
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `trunk check` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
